### PR TITLE
.gitignore에 일반적으로 무시해야할 파일들이 추가되어야 함

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,12 @@
+# common 
+Thumbs.db
+.DS_Store
+.AppleDouble
+.LSOverride
+*.swp
+*.bak
+
+# output
 *.aux
 *.log
 *.lof


### PR DESCRIPTION
OS 등에서 자동으로 생성되지만 일반적으로 무시되어야할 몇 개의 파일들을 .gitgignore에 추가하였습니다. 시스템에 따라 global gitignore이 제대로 설정되어 있지 않을 수 있으므로 필요합니다. ([참고](https://github.com/github/gitignore))
