### PR TITLE
2020년 2월 과학도서관 지적사항 반영

### DIFF
--- a/KUThesis.cls
+++ b/KUThesis.cls
@@ -157,8 +157,8 @@
   \refstepcounter{dummy}
   \makeabstract                            % 초록 페이지 생성
 
-  \pagenumbering{roman}
-  \setcounter{page}{1}
+  %\pagenumbering{roman}                   % 2020년 2월 졸업논문 제출시 과학도서관 지적사항
+  %\setcounter{page}{1}                    % 
   \makecontents
 
   \pagenumbering{arabic}


### PR DESCRIPTION
먼저 졸업논문 템플릿을 만들어서 공개해주신 점에 대해 감사하다는 말씀을 드립니다.

## 요약

저는 2020년 2월 대학원 졸업자이며, KUThesis 템플릿으로 제작한 논문을 과학도서관에 제출하는 과정에서 다음과 같은 지적사항을 받았습니다.

> 로마자로 페이지 번호 기재한 것을 다 지워주시거나
표지 다음부분부터 서론 전까지 로마자로 페이지 번호를 i ii 이런식으로 입력해주세요.

따라서 템플릿에서 Contents, List of Figures, List of Tables 파트의 페이지 번호를 삭제하였습니다.

## 템플릿 패치 사유

과학도서관은 Contents 파트에서 나오는 서론 직전까지의 페이지 번호가 파트별로 하나씩 할당되거나 페이지 번호가 존재하지 않기를 원합니다. 그 결과, 과학도서관은 Contents 파트가 여러 페이지에 걸쳐 있을 때 졸업논문을 반송합니다.

**Ex) Contents 목차 예시 (Contents는 3페이지)**

| 파트 | 기존 템플릿 | 과학도서관 기준 |
|-----|-------------|----------------|
| Contents | i | i or 없음 |
| List of Figures | iv | ii or 없음 |
| List of Tables | v | iii or 없음 |

![image](https://user-images.githubusercontent.com/7675657/73752138-bc24ef80-47a3-11ea-9fce-6aa3a7694e6d.png)

그러나 TeX 템플릿에서 과학도서관이 원하는 대로 페이지 번호를 출력하도록 수정하는 것이 어려웠고, 과학도서관의 요청사항을 제가 제대로 해석한건지 애매했습니다. 따라서 차선책으로 서론 전까지는 페이지 번호를 출력하지 않도록 템플릿을 수정하였습니다.
