### PR TITLE
도서관 지적사항, 인준지 표기

### DIFF
--- a/KUThesis.cls
+++ b/KUThesis.cls
@@ -308,6 +308,14 @@
 }
 \@onlypreamble{\submitDate}
 
+% @command approvalDate 인준일자
+\newcommand{\approvalDate}[3]{
+  \newcommand{\@approvalYear}{#1}
+  \newcommand{\@approvalMonth}{#2}
+  \newcommand{\@approvalDay}{#3}
+}
+\@onlypreamble{\approvalDate}
+
 % @command abstractLineSpacing 초록 줄간격
 \newcommand{\abstractLineSpacing}[1]{
   \FPeval{\@abstractLineRatio}{#1/100.0/1.236} 
@@ -531,32 +539,32 @@
       \begin{center}
         \fontsize{15.5pt}{15.5pt}\selectfont{\bf {\@authorChn}의 \@degreeName{ }{\@degreeChn}士學位論文 審査를 完了함}
         \\[30mm]
-        \fontsize{14pt}{14pt}\selectfont{\bf {\@submitYear}年\ {\@submitMonth}月\ {\@submitDay}日}
+        \fontsize{14pt}{14pt}\selectfont{\bf {\@approvalYear}年\ {\@approvalMonth}月\ {\@approvalDay}日}
         \\[20mm]
         \underline{
-          \fontsize{16pt}{16pt}\selectfont{\bf 委員長}
-          \fontsize{14pt}{14pt}\selectfont{\hspace{60mm}\bf (印)}
+          \fontsize{16pt}{16pt}\selectfont{\bf 委員長 \hspace{20mm}{\@refereeChief}}
+          \fontsize{14pt}{14pt}\selectfont{\hspace{20mm}\bf (印)}
         }
         \\[10mm]
         \underline{
-          \fontsize{16pt}{16pt}\selectfont{\bf 委　員}
-          \fontsize{14pt}{14pt}\selectfont{\hspace{60mm}\bf (印)}
+          \fontsize{16pt}{16pt}\selectfont{\bf 委　員 \hspace{20mm}{\@refereeSecond}}
+          \fontsize{14pt}{14pt}\selectfont{\hspace{20mm}\bf (印)}
         }
         \\[10mm]
         \underline{
-          \fontsize{16pt}{16pt}\selectfont{\bf 委　員}
-          \fontsize{14pt}{14pt}\selectfont{\hspace{60mm}\bf (印)}
+          \fontsize{16pt}{16pt}\selectfont{\bf 委　員 \hspace{20mm}{\@refereeThird}}
+          \fontsize{14pt}{14pt}\selectfont{\hspace{20mm}\bf (印)}
         }
         \if@isDoctor
           \\[10mm]
           \underline{
-            \fontsize{16pt}{16pt}\selectfont{\bf 委　員}
-            \fontsize{14pt}{14pt}\selectfont{\hspace{60mm}\bf (印)}
+            \fontsize{16pt}{16pt}\selectfont{\bf 委　員 \hspace{20mm}{\@refereeFourth}}
+            \fontsize{14pt}{14pt}\selectfont{\hspace{20mm}\bf (印)}
           }
           \\[10mm]
           \underline{
-            \fontsize{16pt}{16pt}\selectfont{\bf 委　員}
-            \fontsize{14pt}{14pt}\selectfont{\hspace{60mm}\bf (印)}
+            \fontsize{16pt}{16pt}\selectfont{\bf 委　員 \hspace{20mm}{\@refereeFifth}}
+            \fontsize{14pt}{14pt}\selectfont{\hspace{20mm}\bf (印)}
           }
         \else\fi
       \end{center}

--- a/thesis.tex
+++ b/thesis.tex
@@ -9,6 +9,7 @@
 %
 % 예제
 % \documentclass[master,final,oneside]{KUThesis}
+% \documentclass[doctor,oneside]{KUThesis}            % draft + oneside
 
 % 기본옵션은 [doctor,twosides,draft] 입니다.
 \documentclass{KUThesis}
@@ -44,7 +45,22 @@ Research on the fact that I cannot say ``father'' to the real father
 \graduateDate{2016}{2}
 
 % 제출 연,월,일
+% 한문 표지에 대한 도서관 안내
+% : 통상적으로 학위논문 표지 날짜는 제출자가 졸업하는 졸업년월((예)2020년 8월, 2021년 2월)
+% : [2021년 8월]처럼 월까지만 기입도 가능, [2021년 8월  일]처럼 비워두는 것은 안 됨
+% 이전에는 심사용 학위논문 제출일/도서관 제출일을 기입하기도 하였음. 정확한 일자는 대학원 행정실에 문의
 \submitDate{2015}{12}{30}
+
+% 인준(심사위원 확인) 연,월,일
+% 도서관 안내: 심사위원 성함이 기재된 인준지에는 학위논문을 심사가 완료된 날짜로 기입하는 경우가 많습니다
+\approvalDate{2015}{12}{15}
+
+% 심사위원 이름
+\referee[1]{이 심 사}            % 심사위원장
+\referee[2]{오 심 사}
+\referee[3]{허 심 사}
+\referee[4]{김 심 사}
+\referee[5]{안 심 사}
 
 % 본문 줄간격 (규정: 170 - 200)
 \captionLineSpacing{150}
@@ -63,7 +79,7 @@ Research on the fact that I cannot say ``father'' to the real father
 % 참고문헌에 헤더를 추가하고 싶은 경우에 주석 해제
 %\addBibHeader
 
-% 스캔한 승인서가 있을 경우 파일 이름 입력. 스캔 파일의 사이즈는 B5이어야 한다.
+% 스캔한 승인서(.pdf)가 있을 경우 파일 이름 입력. 스캔 파일의 사이즈는 A4/B5이어야 한다.
 %\approvalScan{}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
- 인준지 심사위원 이름 표기 추가
- 인준지 심사완료일 지정 추가
- 한문표지/인준지의 표기날짜에 대한 도서관 지적사항 주석 추가
- 기타
 > documentclass에 명시적으로 draft 입력 시 그림이 표시 되지 않아, 착오가 없도록 draft를 위한 documentclass 예제 추가
 > 인준지(승인서)의 파일 확장자가 pdf임을 명시적으로 주석에 표기.
 > 인준지(승인서)를 A4 용지로 pdf스캔하여도 문제 없음 확인.


-----
이번에 박사졸업하게 되면서 큰 도움을 받았습니다. 감사합니다.
인준지(심사위원 서명 페이지)의 날짜와 위원 분들의 성함을 입력하기 편하게 수정하였습니다.

A.
이미 위원이름에 대한 변수가 선언되어 있어 사용하였고,
인준지 날짜만 별도로 설정할 수 있도록 한문 표지 일자를 참고하여 수정하였습니다.
도서관의 안내에 따라 제출일과 서명일이 다를 수 있는 점에서 도움이 될 것 같습니다.

B.
도서관(과학) 제출 과정에서 한문 표지 날짜의 이해에 관하여
인쇄소/도서관/행정실간 상이한 가이드로 인하여 다시 재본하는 일이 있었습니다.
관련하여 시행착오를 통하여 이해한 내용은 다음과 같습니다.

1) 대학원 행정실이 얼마 전 부터 8월/12월로 표지 일자를 지정한다는 점
2) 도서관은 6,7,8월/12,1,2월 등 날짜는 크게 신경쓰지 않아 왔지만, 날짜에 [2000년 2월  일 ] 같이 빈칸을 두면 안된다고 지적 (년/월만 지정, 일 제외 가능: 예) [2000년 2월  25일], [2000년 2월])
3) 인쇄소에서 오래 전 부터 한자표지의 날짜를 심사 전 제출일( < 심사서명 날짜)로 하였던 역사성을 강하게 주장한 점
- 이에 따라 [2000년 12월  일 ]과 같이 제본한 사례가 많았다고 주장
4) 도서관 제출일을 한문 표지에 기입한 사례도 존재

결론적으로 1)에 따라 [년월] 또는 [년월일]을 기입하고 그 방식/일자는 행정실의 공지를 따라야한다는 것이 원칙으로 정리가 되었습니다.
이 내용을 필요한 핵심만 추려 주석으로 적어두었습니다.

C.
documentclass에 명시적으로 draft 입력한 것 때문에 그림이 표시 되지 않았는데
원인을 몰라 한참 고생하였습니다. 착오가 없도록 draft를 위한 documentclass 예제를 추가했습니다.

D. (다음은 반영이 안되도 상관은 없을 것 같습니다.)
인준지(심사지) 첨부를 .pdf로 한다는 것을 명시적으로 주석에 적어두면
사용하기 편할 것 같아 해당 주석 수정하였습니다.
저는 A4용지에 서명을 받아 PDF로 스캔하여 사용하여는데 전혀 문제가 없었습니다.
비율만 맞으면 꼭 B5가 아니어도 괜찮은 것 같습니다.
다만, A4보다는 인쇄소에서 서명용 논문 용지(B5)를 받아 진행하는 것이 더 좋아보이긴 합니다. 
이 부분은 Pull request 드린 이후 생간난 부분이라 참고해주시면 좋을 것 같습니다.

감사합니다.